### PR TITLE
メインレイアウト内のnuxtタグを囲うv-containerタグをページコンポーネントに移動

### DIFF
--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -16,9 +16,7 @@
       </v-row>
     </v-app-bar>
     <v-main>
-      <v-container fluid>
-        <nuxt />
-      </v-container>
+      <nuxt />
     </v-main>
     <v-footer class="grey darken-4" app>
       <v-row no-gutters>

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -1,30 +1,32 @@
 <template>
-  <v-row>
-    <v-col cols="12">
-      <v-card>
-        <v-card-title class="d-flex flex-column justify-center">
-          <v-avatar
-            v-if="!($store.state.nodeEnv === 'production')"
-            v-bind:class="[
-              user.avatar.url === '/images/fallback/default.png'
-                ? 'grey lighten-2'
-                : 'blue-grey lighten-2',
-            ]"
-            size="128"
-          >
-            <v-img
-              v-bind:src="`${$config.axios.browserBaseURL}` + user.avatar.url"
-              max-height="90%"
-              max-width="90%"
-            ></v-img>
-          </v-avatar>
-          <v-card-text class="text-center">
-            {{ user.name }}
-          </v-card-text>
-        </v-card-title>
-      </v-card>
-    </v-col>
-  </v-row>
+  <v-container fluid>
+    <v-row>
+      <v-col cols="12">
+        <v-card>
+          <v-card-title class="d-flex flex-column justify-center">
+            <v-avatar
+              v-if="!($store.state.nodeEnv === 'production')"
+              v-bind:class="[
+                user.avatar.url === '/images/fallback/default.png'
+                  ? 'grey lighten-2'
+                  : 'blue-grey lighten-2',
+              ]"
+              size="128"
+            >
+              <v-img
+                v-bind:src="`${$config.axios.browserBaseURL}` + user.avatar.url"
+                max-height="90%"
+                max-width="90%"
+              ></v-img>
+            </v-avatar>
+            <v-card-text class="text-center">
+              {{ user.name }}
+            </v-card-text>
+          </v-card-title>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>


### PR DESCRIPTION
close #17

# 概要

# 変更内容
- メインレイアウト内のnuxtタグを囲うv-containerタグをページコンポーネントに移動

# 補足
