### PR TITLE
Userモデルのavatar属性にファイルサイズを制限するバリデーションを追加

### DIFF
--- a/backend/app/uploaders/avatar_uploader.rb
+++ b/backend/app/uploaders/avatar_uploader.rb
@@ -24,4 +24,8 @@ class AvatarUploader < CarrierWave::Uploader::Base
   def extension_allowlist
     %w[jpg jpeg gif png]
   end
+
+  def size_range
+    1.byte...10.megabytes
+  end
 end


### PR DESCRIPTION
close #48

# 概要

# 変更内容
- Userモデルのavatar属性にファイルサイズを制限するバリデーションを追加

# 補足