### PR TITLE
新規ユーザー登録時に自動的に認証状態を保持する機能を追加

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -17,6 +17,7 @@ module Api
       def create
         user = User.new(user_params)
         if user.save
+          session[:user_id] = user.id
           render json: { user: user }
         else
           errors = user.errors.full_messages

--- a/backend/spec/requests/users_spec.rb
+++ b/backend/spec/requests/users_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe "Users", type: :request do
           } }
         }.to change(User, :count).by(1)
       end
+      it "cookieに一時的な暗号化済みのユーザーIDが生成されること" do
+        post "/api/v1/signup", params: { user: {
+          name: @valid_name,
+          email: @valid_email,
+          password: @valid_password,
+          password_confirmation: @valid_password
+        } }
+        expect(session[:user_id].blank?).to be_falsey
+      end
     end
     context "パラメータが不当な場合" do
       before do


### PR DESCRIPTION
close #50

# 概要

# 変更内容
- 新規ユーザー登録時に自動的に認証状態を保持する機能を追加

# 補足