### PR TITLE
ユーザー認証時に永続的なユーザー認証機能に関するv-checkboxタグが持つブール値が真になる不具合を修正

### DIFF
--- a/backend/app/controllers/api/v1/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/sessions_controller.rb
@@ -19,7 +19,7 @@ module Api
         if unauth_user.valid?
           auth_user = User.find_by(email: params[:session][:email].downcase)
           session[:user_id] = auth_user.id
-          params[:session][:remember_me] == "1" ? remember(auth_user) : forget(auth_user)
+          params[:session][:remember_me] == true ? remember(auth_user) : forget(auth_user)
           render json: { auth_user: auth_user }
         else
           errors = unauth_user.errors.full_messages

--- a/backend/spec/requests/sessions_spec.rb
+++ b/backend/spec/requests/sessions_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe "Sessions", type: :request do
 
   describe "'/login'にPOSTメソッドでリクエストを送信" do
     let!(:unauth_user) { FactoryBot.build(:unauth_user) }
+    let!(:headers) { { "Content-Type" => "application/json" } }
     context "パラメータが妥当かつ「ログイン情報を保存する」をチェックする場合" do
       let!(:user) { FactoryBot.create(:user) }
       before do
@@ -69,24 +70,24 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         expect(response.status).to eq 200
       end
       it "cookieに一時的な暗号化済みのユーザーIDが生成されること" do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         expect(session[:user_id].blank?).to be_falsey
       end
       it "cookieに永続的な暗号化済みのユーザーIDと永続的な暗号化済みの記憶トークンが生成されること" do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         expect(cookies.permanent.signed[:user_id].blank?).to be_falsey
         expect(cookies.permanent[:remember_token].blank?).to be_falsey
       end
@@ -94,8 +95,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         auth_user = User.find(user.id)
         expect(auth_user.remember_digest.nil?).to be_falsey
       end
@@ -103,8 +104,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         json = JSON.parse(response.body)
         expect(json["auth_user"]["id"]).to eq(user.id)
       end
@@ -119,24 +120,24 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         expect(response.status).to eq 200
       end
       it "cookieに一時的な暗号化済みのユーザーIDが生成されること" do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         expect(session[:user_id].blank?).to be_falsey
       end
       it "cookieに永続的な暗号化済みのユーザーIDと永続的な暗号化済みの記憶トークンが生成されないこと" do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         expect(cookies.permanent.signed[:user_id].blank?).to be_truthy
         expect(cookies.permanent[:remember_token].blank?).to be_truthy
       end
@@ -144,8 +145,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         auth_user = User.find(user.id)
         expect(auth_user.remember_digest.nil?).to be_truthy
       end
@@ -153,8 +154,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: @valid_email,
           password: @valid_password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         json = JSON.parse(response.body)
         expect(json["auth_user"]["id"]).to eq(user.id)
       end
@@ -184,13 +185,14 @@ RSpec.describe "Sessions", type: :request do
 
   describe "'/logout'にDELETEメソッドでリクエストを送信" do
     let!(:user) { FactoryBot.create(:user) }
+    let!(:headers) { { "Content-Type" => "application/json" } }
     context "「ログイン情報を保存する」にチェックしてログインした既認証ユーザーがログアウトした場合" do
       it "ステータスコード204 (no content) が返されること" do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         delete "/api/v1/logout"
         expect(response.status).to eq 204
       end
@@ -198,8 +200,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         delete "/api/v1/logout"
         expect(session[:user_id].blank?).to be_truthy
       end
@@ -207,8 +209,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         delete "/api/v1/logout"
         expect(cookies.permanent.signed[:user_id].blank?).to be_truthy
         expect(cookies.permanent[:remember_token].blank?).to be_truthy
@@ -217,8 +219,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         delete "/api/v1/logout"
         unauth_user = User.find(user.id)
         expect(unauth_user.remember_digest.nil?).to be_truthy
@@ -227,8 +229,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "1"
-        } }
+          remember_me: true
+        } }.to_json, headers: headers
         delete "/api/v1/logout"
         expect(session[:user_id].blank?).to be_truthy
         delete "/api/v1/logout"
@@ -240,8 +242,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         delete "/api/v1/logout"
         expect(response.status).to eq 204
       end
@@ -249,8 +251,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         delete "/api/v1/logout"
         expect(session[:user_id].blank?).to be_truthy
       end
@@ -258,8 +260,8 @@ RSpec.describe "Sessions", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         delete "/api/v1/logout"
         expect(session[:user_id].blank?).to be_truthy
         delete "/api/v1/logout"

--- a/backend/spec/requests/users_spec.rb
+++ b/backend/spec/requests/users_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe "Users", type: :request do
   end
 
   describe "'/users/:id/edit'にGETメソッドでリクエストを送信" do
+    let!(:headers) { { "Content-Type" => "application/json" } }
     context "ユーザーがログインしていない場合" do
       let!(:user) { FactoryBot.create(:user) }
       it "ステータスコード403 (forbidden) が返されること" do
@@ -130,8 +131,8 @@ RSpec.describe "Users", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         get "/api/v1/users/#{user.id}/edit"
         expect(response.status).to eq 200
       end
@@ -139,8 +140,8 @@ RSpec.describe "Users", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         get "/api/v1/users/#{user.id}/edit"
         json = JSON.parse(response.body)
         expect(json["user"]["id"]).to eq(user.id)
@@ -153,8 +154,8 @@ RSpec.describe "Users", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         get "/api/v1/users/#{another_user.id}/edit"
         expect(response.status).to eq 403
       end
@@ -162,8 +163,8 @@ RSpec.describe "Users", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         get "/api/v1/users/#{another_user.id}/edit"
         json = JSON.parse(response.body)
         expect(json["message"]).to eq("ユーザーが正しくありません")
@@ -172,6 +173,7 @@ RSpec.describe "Users", type: :request do
   end
 
   describe "'/users/:id'にPATCHメソッドでリクエストを送信" do
+    let!(:headers) { { "Content-Type" => "application/json" } }
     context "ユーザーがログインしていない場合" do
       let!(:user) { FactoryBot.create(:user) }
       it "ステータスコード403 (forbidden) が返されること" do
@@ -201,8 +203,8 @@ RSpec.describe "Users", type: :request do
           post "/api/v1/login", params: { session: {
             email: user.email,
             password: user.password,
-            remember_me: "0"
-          } }
+            remember_me: false
+          } }.to_json, headers: headers
           patch "/api/v1/users/#{user.id}", params: { user: {
             name: user.name.insert(8, "Update "),
             email: user.email.sub(/user/, "update-user"),
@@ -215,8 +217,8 @@ RSpec.describe "Users", type: :request do
           post "/api/v1/login", params: { session: {
             email: user.email,
             password: user.password,
-            remember_me: "0"
-          } }
+            remember_me: false
+          } }.to_json, headers: headers
           patch "/api/v1/users/#{user.id}", params: { user: {
             name: user.name.insert(8, "Update "),
             email: user.email.sub(/user/, "update-user"),
@@ -233,8 +235,8 @@ RSpec.describe "Users", type: :request do
           post "/api/v1/login", params: { session: {
             email: user.email,
             password: user.password,
-            remember_me: "0"
-          } }
+            remember_me: false
+          } }.to_json, headers: headers
           patch "/api/v1/users/#{user.id}", params: { user: {
             name: user.name.split(/\s/).first,
             email: user.email.sub(/@/, "_"),
@@ -247,8 +249,8 @@ RSpec.describe "Users", type: :request do
           post "/api/v1/login", params: { session: {
             email: user.email,
             password: user.password,
-            remember_me: "0"
-          } }
+            remember_me: false
+          } }.to_json, headers: headers
           patch "/api/v1/users/#{user.id}", params: { user: {
             name: user.name.split(/\s/).first,
             email: user.email.sub(/@/, "_"),
@@ -267,8 +269,8 @@ RSpec.describe "Users", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         patch "/api/v1/users/#{another_user.id}", params: { user: {
           name: another_user.name.insert(8, "Update "),
           email: another_user.email.sub(/another-user/, "update-another-user"),
@@ -281,8 +283,8 @@ RSpec.describe "Users", type: :request do
         post "/api/v1/login", params: { session: {
           email: user.email,
           password: user.password,
-          remember_me: "0"
-        } }
+          remember_me: false
+        } }.to_json, headers: headers
         patch "/api/v1/users/#{another_user.id}", params: { user: {
           name: another_user.name.insert(8, "Update "),
           email: another_user.email.sub(/another-user/, "update-another-user"),

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -175,9 +175,9 @@ export default {
         this.loader = 'loading'
         const userRememberMe = document.getElementById('userRememberMe')
         if (userRememberMe.checked) {
-          this.user.remember_me = '1'
+          this.user.remember_me = true
         } else {
-          this.user.remember_me = '0'
+          this.user.remember_me = false
         }
         const response = await this.$axios.$post('/api/v1/login', {
           session: {


### PR DESCRIPTION
close #72

# 概要

# 変更内容
- ユーザー認証時に永続的なユーザー認証機能に関するv-checkboxタグが持つブール値が真になる不具合を修正

# 補足