### PR TITLE
既認証ヘッダーのユーザー一覧表示機能への導線を認識させるマテリアルデザインアイコンのデータバインディングをディレクティブからマスタッシュ構文に変更

### DIFF
--- a/frontend/components/AuthenticatedHeaderItem.vue
+++ b/frontend/components/AuthenticatedHeaderItem.vue
@@ -7,10 +7,8 @@
         flat
       >
         <router-link to="/users" exact>
-          <v-icon
-            class="grey--text text--lighten-4"
-            v-text="authenticatedHeaderUsers.icon.mdiAccountBoxMultipleOutline"
-          >
+          <v-icon class="grey--text text--lighten-4">
+            {{ authenticatedHeaderUsers.icon.mdiAccountBoxMultipleOutline }}
           </v-icon>
         </router-link>
       </v-card>


### PR DESCRIPTION
close #80

# 概要

# 変更内容
- 既認証ヘッダーのユーザー一覧表示機能への導線を認識させるマテリアルデザインアイコンのデータバインディングをディレクティブからマスタッシュ構文に変更

# 補足