### PR TITLE
既認証ヘッダーの認証破棄機能を識別させる見出しを非データバインディングに変更

### DIFF
--- a/frontend/components/AuthenticatedHeaderItem.vue
+++ b/frontend/components/AuthenticatedHeaderItem.vue
@@ -98,9 +98,7 @@
               ></v-icon>
             </v-list-item-icon>
             <v-list-item-content>
-              <v-list-item-title
-                v-text="authenticatedHeaderLogout.title"
-              ></v-list-item-title>
+              <v-list-item-title>ログアウト</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
         </v-list>
@@ -125,7 +123,6 @@ export default {
         icon: { mdiAccountBoxMultipleOutline: mdiAccountBoxMultipleOutline },
       },
       authenticatedHeaderLogout: {
-        title: 'ログアウト',
         icon: { mdiLogout: mdiLogout },
       },
     }


### PR DESCRIPTION
close #82

# 概要

# 変更内容
- 既認証ヘッダーの認証破棄機能を識別させる見出しを非データバインディングに変更

# 補足