### PR TITLE
既認証ヘッダーの認証破棄機能への導線を認識させるマテリアルデザインアイコンのデータバインディングをディレクティブからマスタッシュ構文に変更

### DIFF
--- a/frontend/components/AuthenticatedHeaderItem.vue
+++ b/frontend/components/AuthenticatedHeaderItem.vue
@@ -93,9 +93,7 @@
           <v-divider class="my-3"></v-divider>
           <v-list-item v-on:click="logoutUser()">
             <v-list-item-icon>
-              <v-icon
-                v-text="authenticatedHeaderLogout.icon.mdiLogout"
-              ></v-icon>
+              <v-icon>{{ authenticatedHeaderLogout.icon.mdiLogout }}</v-icon>
             </v-list-item-icon>
             <v-list-item-content>
               <v-list-item-title>ログアウト</v-list-item-title>


### PR DESCRIPTION
close #84

# 概要

# 変更内容
- 既認証ヘッダーの認証破棄機能への導線を認識させるマテリアルデザインアイコンのデータバインディングをディレクティブからマスタッシュ構文に変更

# 補足