### PR TITLE
既認証ヘッダーのマテリアルデザインアイコンをインポートする順序をアルファベットの昇順に変更

### DIFF
--- a/frontend/components/AuthenticatedHeaderItem.vue
+++ b/frontend/components/AuthenticatedHeaderItem.vue
@@ -120,11 +120,11 @@
 
 <script>
 import {
-  mdiLogout,
   mdiAccount,
+  mdiAccountBoxMultipleOutline,
   mdiAccountEdit,
   mdiImage,
-  mdiAccountBoxMultipleOutline,
+  mdiLogout,
 } from '@mdi/js'
 
 export default {


### PR DESCRIPTION
close #90

# 概要

# 変更内容
- 既認証ヘッダーのマテリアルデザインアイコンをインポートする順序をアルファベットの昇順に変更

# 補足