### PR TITLE
ユーザー表示機能、既存ユーザー更新機能、既認証ヘッダーのVuexストアから環境変数NODE_ENVを取得する手段をcomputedプロパティに限定

### DIFF
--- a/frontend/components/AuthenticatedHeaderItem.vue
+++ b/frontend/components/AuthenticatedHeaderItem.vue
@@ -44,7 +44,7 @@
         <template v-slot:activator="{ on }">
           <v-hover v-slot="{ hover }">
             <v-avatar
-              v-if="!($store.state.nodeEnv === 'production')"
+              v-if="!(nodeEnv === 'production')"
               v-bind:class="[
                 authUser.avatar.url === '/images/fallback/default.png'
                   ? 'grey lighten-2'
@@ -148,6 +148,9 @@ export default {
     }
   },
   computed: {
+    nodeEnv: function () {
+      return this.$store.state.nodeEnv
+    },
     authUser: function () {
       return this.$store.state.authentication.authUser
     },

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -5,7 +5,7 @@
         <v-card>
           <v-card-title class="d-flex flex-column justify-center">
             <v-avatar
-              v-if="!($store.state.nodeEnv === 'production')"
+              v-if="!(nodeEnv === 'production')"
               v-bind:class="[
                 user.avatar.url === '/images/fallback/default.png'
                   ? 'grey lighten-2'
@@ -42,6 +42,11 @@ export default {
     return {
       user: response.user,
     }
+  },
+  computed: {
+    nodeEnv: function () {
+      return this.$store.state.nodeEnv
+    },
   },
   methods: {
     assignUpdatedUser: function (updatedUser) {

--- a/frontend/pages/users/_id/edit/avatar.vue
+++ b/frontend/pages/users/_id/edit/avatar.vue
@@ -9,7 +9,7 @@
 
       <v-card-title>
         <v-avatar
-          v-if="!($store.state.nodeEnv === 'production')"
+          v-if="!(nodeEnv === 'production')"
           v-bind:class="[
             user.avatar.url === '/images/fallback/default.png'
               ? 'grey lighten-2'
@@ -141,6 +141,11 @@ export default {
       uploadFile: null,
       updateUserAvatarErrors: {},
     }
+  },
+  computed: {
+    nodeEnv: function () {
+      return this.$store.state.nodeEnv
+    },
   },
   watch: {
     loader: function () {


### PR DESCRIPTION
close #95

# 概要

# 変更内容
- ユーザー表示機能、既存ユーザー更新機能、既認証ヘッダーのVuexストアから環境変数NODE_ENVを取得する手段をcomputedプロパティに限定

# 補足